### PR TITLE
Add a GitHub Action based release process

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,12 +27,12 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Install dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,72 @@
+name: Release PFS
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref_name, github.ref_name) && contains(github.ref_name, '-v')
+    steps:
+      - name: Parse tag
+        id: parse
+        # Only run when the tag matches the pattern, e.g. SR-v5.0.1
+        # Output variables for later use: pfs, version, output_dir, location
+        run: |
+          TAG="${{ github.ref_name }}"
+          if [[ ! "$TAG" =~ ^([A-Z]{2,4})-(v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "Tag '$TAG' does not match expected pattern [A-Z]{2,4}-v#.#.#"
+            exit 1
+          fi
+          PFS="${BASH_REMATCH[1]}"
+          VERSION="${BASH_REMATCH[2]}"
+          echo "pfs=$PFS" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "output_dir=build/CEOS-ARD-PFS-$PFS" >> "$GITHUB_OUTPUT"
+          echo "location=build/CEOS-ARD-PFS-$PFS-$VERSION" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+          
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+        
+      - name: Install pandoc
+        run: |
+          curl https://github.com/jgm/pandoc/releases/download/3.8.2.1/pandoc-3.8.2.1-1-amd64.deb -L -o pandoc.deb
+          sudo dpkg -i pandoc.deb
+          pandoc --version
+      
+      - name: Install pandoc-crossref
+        run: |
+          curl https://github.com/lierdakil/pandoc-crossref/releases/download/v0.3.22/pandoc-crossref-Linux-X64.tar.xz -L -o pandoc-crossref.tar.xz
+          tar -xf pandoc-crossref.tar.xz
+          sudo mv pandoc-crossref /usr/local/bin
+          pandoc-crossref --version
+      
+      - name: Install browser for PDF generation
+        run: python -m playwright install chromium --with-deps
+
+      - name: Generate PFS documents
+        run: >
+          ceos-ard generate ${{ steps.parse.outputs.pfs }}
+          -o ${{ steps.parse.outputs.output_dir }}
+          --self-contained
+          --stable
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OUTPUT_DIR="${{ steps.parse.outputs.output_dir }}"
+          for ext in pdf html docx; do
+            file=$(find "$OUTPUT_DIR" -maxdepth 1 -name "*.${ext}" | head -n 1)
+            if [ -n "$file" ]; then
+              gh release upload "${{ github.ref_name }}" "$file" --clobber
+            fi
+          done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,13 +22,14 @@ All pull requests additionally require a review of a CEOS-ARD team members.
 
 ## Release Process
 
-The CI already already creates Editor's Drafts. These can be used to create releases.
+To release a specific PFS document, create a GitHub Release with a tag following the pattern `<PFS>-v<major>.<minor>.<patch>`, e.g. `SR-v5.0.1`.
 
-Use that file, check whether everything looks good and then create PDF from it.
+The release workflow will automatically:
 
-These two files can then be uploaded to the CEOS-ARD website.
+1. Generate the release documents (PDF, HTML, DOCX) using the CEOS-ARD CLI.
+2. Attach the generated files to the GitHub Release.
 
-Also make sure to update the tables in the README files and on the CEOS-ARD website.
-In the README files make sure to add the now outdated version version to the
-"Older Versions" table at the top. Also update the links and version number in
-the "Released Version" section.
+After the release is published, get the newly generated PFS documents from the
+[Releases page on the ceos-ard GitHub repository](https://github.com/ceos-org/ceos-ard/releases).
+
+Upload these documents to the CEOS-ARD website.


### PR DESCRIPTION
Add a GitHub Action based release process.

We could also upload the files automatically to the CEOS-ARD website via FTP or so.