### PR TITLE
Reference the previous SAR PFS to the document history

### DIFF
--- a/pfs/GSLC/document.yaml
+++ b/pfs/GSLC/document.yaml
@@ -157,4 +157,6 @@ changes:
       - Requirement "CEOS-ARD Product Data Attributes" renamed to “Product Metadata”; Requirement "Source Data Attributes" renamed to “Source Metadata”. Adapted descriptions accordingly.
       - Requirement "Source Data Attributes": Moved the information about sequential acquisition identifiers to a new threshold requirement “Acquisition ID”. Adapted category description accordingly.
       - Annex has been reformatted and updated as required by the split
+
+      **Note:** This document is the successor of the former [CEOS-ARD for SAR PFS v1.3](https://ceos.org/ard/files/PFS/SAR/v1.3/CEOS-ARD_PFS_Synthetic_Aperture_Radar_v1.3.pdf) for product type "GSLC".
     reason: Migration to building blocks.

--- a/pfs/NRB/document.yaml
+++ b/pfs/NRB/document.yaml
@@ -149,4 +149,6 @@ changes:
       - Requirement "CEOS-ARD Product Data Attributes" renamed to “Product Metadata”; Requirement "Source Data Attributes" renamed to “Source Metadata”. Adapted descriptions accordingly.
       - Requirement "Source Data Attributes": Moved the information about sequential acquisition identifiers to a new threshold requirement “Acquisition ID”. Adapted category description accordingly.
       - Annex has been reformatted and updated as required by the split
+
+      **Note:** This document is the successor of the former [CEOS-ARD for SAR PFS v1.3](https://ceos.org/ard/files/PFS/SAR/v1.3/CEOS-ARD_PFS_Synthetic_Aperture_Radar_v1.3.pdf) for product type "NRB".
     reason: Migration to building blocks.

--- a/pfs/ORB/document.yaml
+++ b/pfs/ORB/document.yaml
@@ -145,4 +145,6 @@ changes:
       - Requirement "CEOS-ARD Product Data Attributes" renamed to “Product Metadata”; Requirement "Source Data Attributes" renamed to “Source Metadata”. Adapted descriptions accordingly.
       - Requirement "Source Data Attributes": Moved the information about sequential acquisition identifiers to a new threshold requirement “Acquisition ID”. Adapted category description accordingly.
       - Annex has been reformatted and updated as required by the split
+
+      **Note:** This document is the successor of the former [CEOS-ARD for SAR PFS v1.3](https://ceos.org/ard/files/PFS/SAR/v1.3/CEOS-ARD_PFS_Synthetic_Aperture_Radar_v1.3.pdf) for product type "ORB".
     reason: Migration to building blocks.

--- a/pfs/POL/document.yaml
+++ b/pfs/POL/document.yaml
@@ -183,4 +183,6 @@ changes:
       - Requirement "CEOS-ARD Product Data Attributes" renamed to “Product Metadata”; Requirement "Source Data Attributes" renamed to “Source Metadata”. Adapted descriptions accordingly.
       - Requirement "Source Data Attributes": Moved the information about sequential acquisition identifiers to a new threshold requirement “Acquisition ID”. Adapted category description accordingly.
       - Annex has been reformatted and updated as required by the split
+
+      **Note:** This document is the successor of the former [CEOS-ARD for SAR PFS v1.3](https://ceos.org/ard/files/PFS/SAR/v1.3/CEOS-ARD_PFS_Synthetic_Aperture_Radar_v1.3.pdf) for product type "POL".
     reason: Migration to building blocks.


### PR DESCRIPTION
Add reference to the previous version/document of the SAR PFS to the document history.
This was requested in the SAR group call on 2026-05-25.

@akerosenqvist Please confirm that the document name is correct.

We also need to confirm the link to the document is correct once v1.3 is published.

Example for NRB:
<img width="823" height="612" alt="{EC034138-D6B0-449C-B210-B8A3BBC9A260}" src="https://github.com/user-attachments/assets/c90e6060-9760-417b-942b-2357a3443b16" />
