### PR TITLE
Fix error in NLSR PFS Applies to statement

### DIFF
--- a/pfs/NLSR/document.yaml
+++ b/pfs/NLSR/document.yaml
@@ -81,6 +81,12 @@ authors:
   - Zhuosen Wang, University of Maryland/GSFC, USA
 
 changes:
+  - date: 2026-08-31
+    author: Harvey Jones
+    level: patch
+    change: |-
+      - Updated 'Applies to' statement
+    reason: Minor editorial update
   - date: 2026-03-26
     author: Matthias Mohr
     level: patch

--- a/pfs/NLSR/document.yaml
+++ b/pfs/NLSR/document.yaml
@@ -1,11 +1,11 @@
 title: Nighttime Lights Surface Radiance
 version: 1.0.1
 type: Optical
-applies_to: Data collected by Synthetic Aperture Radar sensors
-background: |-
-  Data collected with nighttime light sensors operating in the VIS/NIR wavelengths.
+applies_to: Data collected with nighttime light sensors operating in the VIS/NIR wavelengths.
   These typically operate with ground sample distance and resolution in the order of 10-1000m;
   however, the Specification is not inherently limited to this resolution.
+background:
+  
 
 glossary:
   - nlsr


### PR DESCRIPTION
Remove 'Data collected by Synthetic Aperture Radar sensors' from the NLSR PFS 'Applies to' statement. 

I believe this was added in error during the building block conversion, the PFS does not apply to SAR sensors. 

This pull request would restore the 'Applies to' statement from [v1.0.0](https://ceos.org/ard/files/PFS/NLSR/v1.0/CARD4L_Product_Family_Specification_Nighttime_Light_Radiance-v1.0.pdf).